### PR TITLE
Declare minimum PHP version to match the minimum version we test with

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": "^5|^7|^8"
+    "php": "^5.5|^7|^8"
   },
   "require-dev": {
     "phpunit/phpunit": "^4|^5|^7|^8|^9"


### PR DESCRIPTION
Previously the package declared compatibility with PHP v`^5`, but clearly, it won't work with anything below 5.3 (due to namespaces), so it makes sense to bump it to the minimum version we test with.
