### PR TITLE
InvalidArgumentException docblock fixes

### DIFF
--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -7,7 +7,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param mixed $callback
      * @param string $callee
-     * @param integer $parameterPosition
+     * @param int $parameterPosition
      * @throws InvalidArgumentException
      */
     public static function assertCallback($callback, $callee, $parameterPosition)
@@ -83,8 +83,8 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param mixed $propertyName
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     public static function assertPropertyName($propertyName, $callee, $parameterPosition)
     {
@@ -160,10 +160,10 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param boolean $value
+     * @param mixed $value
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     public static function assertBoolean($value, $callee, $parameterPosition)
     {
@@ -182,8 +182,8 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param mixed $value
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     public static function assertInteger($value, $callee, $parameterPosition)
     {
@@ -200,11 +200,11 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param integer $value
-     * @param integer $limit
+     * @param mixed $value
+     * @param int $limit
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     public static function assertIntegerGreaterThanOrEqual($value, $limit, $callee, $parameterPosition)
     {
@@ -221,11 +221,11 @@ class InvalidArgumentException extends \InvalidArgumentException
     }
 
     /**
-     * @param integer $value
-     * @param integer $limit
+     * @param mixed $value
+     * @param int $limit
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     public static function assertIntegerLessThanOrEqual($value, $limit, $callee, $parameterPosition)
     {
@@ -254,8 +254,8 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param mixed $list
      * @param string $className
      * @param string $callee
-     * @param integer $parameterPosition
-     * @throws InvalidArgumentException
+     * @param int $parameterPosition
+     * @throws static
      */
     private static function assertListAlike($list, $className, $callee, $parameterPosition)
     {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -57,16 +57,37 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $list
+     * @param string $callee
+     * @param int $parameterPosition
+     * @return void
+     * @throws static
+     */
     public static function assertList($list, $callee, $parameterPosition)
     {
         self::assertListAlike($list, 'Traversable', $callee, $parameterPosition);
     }
 
+    /**
+     * @param mixed $collection
+     * @param string $callee
+     * @param int $parameterPosition
+     * @return void
+     * @throws static
+     */
     public static function assertArrayAccess($collection, $callee, $parameterPosition)
     {
         self::assertListAlike($collection, 'ArrayAccess', $callee, $parameterPosition);
     }
 
+    /**
+     * @param mixed $methodName
+     * @param string $callee
+     * @param int $parameterPosition
+     * @return void
+     * @throws static
+     */
     public static function assertMethodName($methodName, $callee, $parameterPosition)
     {
         if (!is_string($methodName)) {
@@ -107,6 +128,13 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $value
+     * @param string $callee
+     * @param int $parameterPosition
+     * @return void
+     * @throws static
+     */
     public static function assertPositiveInteger($value, $callee, $parameterPosition)
     {
         if ((string)(int)$value !== (string)$value || $value < 0) {
@@ -149,6 +177,13 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $collection
+     * @param mixed $key
+     * @param string $callee
+     * @return void
+     * @throws static
+     */
     public static function assertArrayKeyExists($collection, $key, $callee)
     {
         if (!isset($collection[$key])) {
@@ -248,6 +283,12 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param array<array-key, mixed> $args
+     * @param int $position
+     * @return void
+     * @throws static
+     */
     public static function assertResolvablePlaceholder(array $args, $position)
     {
         if (count($args) === 0) {
@@ -280,6 +321,12 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $value
+     * @param string $callee
+     * @return void
+     * @throws static
+     */
     public static function assertNonZeroInteger($value, $callee)
     {
         if (!is_int($value) || $value == 0) {
@@ -287,6 +334,13 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $pair
+     * @param string $callee
+     * @param int $position
+     * @return void
+     * @throws static
+     */
     public static function assertPair($pair, $callee, $position)
     {
         if (!(is_array($pair) || $pair instanceof \ArrayAccess) || !isset($pair[0], $pair[1])) {
@@ -298,6 +352,10 @@ class InvalidArgumentException extends \InvalidArgumentException
         }
     }
 
+    /**
+     * @param mixed $value
+     * @return string
+     */
     private static function getType($value)
     {
         return is_object($value) ? get_class($value) : gettype($value);

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -8,6 +8,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param mixed $callback
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws InvalidArgumentException
      */
     public static function assertCallback($callback, $callee, $parameterPosition)
@@ -84,6 +85,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param mixed $propertyName
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     public static function assertPropertyName($propertyName, $callee, $parameterPosition)
@@ -125,6 +127,7 @@ class InvalidArgumentException extends \InvalidArgumentException
     /**
      * @param mixed $key
      * @param string $callee
+     * @return void
      * @throws static
      */
     public static function assertValidArrayKey($key, $callee)
@@ -163,6 +166,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param mixed $value
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     public static function assertBoolean($value, $callee, $parameterPosition)
@@ -183,6 +187,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param mixed $value
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     public static function assertInteger($value, $callee, $parameterPosition)
@@ -204,6 +209,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param int $limit
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     public static function assertIntegerGreaterThanOrEqual($value, $limit, $callee, $parameterPosition)
@@ -225,6 +231,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param int $limit
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     public static function assertIntegerLessThanOrEqual($value, $limit, $callee, $parameterPosition)
@@ -255,6 +262,7 @@ class InvalidArgumentException extends \InvalidArgumentException
      * @param string $className
      * @param string $callee
      * @param int $parameterPosition
+     * @return void
      * @throws static
      */
     private static function assertListAlike($list, $className, $callee, $parameterPosition)


### PR DESCRIPTION
`InvalidArgumentException` docblock fixes.

* Uniform docblock type names (s/boolean/bool, s/integer/int)
* Uniform `@throws static`
* Uniform `@return void` (where applicable)
* Added missing docblocks
